### PR TITLE
Fixing json_pure dependency problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :test do
+  gem "json_pure", '2.0.1' if RUBY_VERSION < '2.0'
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.5'
   gem "rspec-core", '< 3.2' if RUBY_VERSION < '1.9'


### PR DESCRIPTION
The json_pure gem dropped ruby <2.0 compatibility in version 2.0.2.
This leads (since today) to travis tests failing on the `bundle install` task for ruby 1.9.
Changing the Gemfile to take that in account as it is a dependency of one of the gems we currently use.
